### PR TITLE
Use stricter Miri flags on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       with:
         command: miri
         args: test
+      env:
+        RUSTFLAGS: -Zrandomize-layout
+        MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check
 
   rustfmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We shouldn't be violating this, but it's good to check it.