### PR TITLE
Move `SemaphorePermit` to `semaphore::Permit`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,14 +106,14 @@ mod broad_rc;
 pub mod broadcast;
 pub mod once_cell;
 pub mod oneshot;
-mod semaphore;
+pub mod semaphore;
 pub mod spsc;
 pub mod wait_list;
 
 #[doc(no_inline)]
 pub use once_cell::OnceCell;
+#[doc(no_inline)]
 pub use semaphore::Semaphore;
-pub use semaphore::SemaphorePermit;
 
 #[cfg(test)]
 mod test_util {


### PR DESCRIPTION
I don't think there's much difference between the two at this point, but if we ever end up adding `RcPermit` and/or `ArcPermit` (or even named futures) it's beneficial to not clutter the crate root - it's also shorter to type in the module.