### PR TITLE
Deny `unsafe_op_in_unsafe_fn` everywhere

### DIFF
--- a/src/bi_rc.rs
+++ b/src/bi_rc.rs
@@ -49,7 +49,7 @@ impl<T> BiRc<T> {
     /// Caller must ensure that the reference returned by `get_mut_unchecked` is
     /// only used by one caller at the same time.
     pub unsafe fn get_mut_unchecked(&self) -> (&mut T, bool) {
-        let inner = &mut (*self.inner.as_ptr());
+        let inner = unsafe { &mut (*self.inner.as_ptr()) };
         (inner.value.get_mut(), inner.count == 2)
     }
 }

--- a/src/broad_rc.rs
+++ b/src/broad_rc.rs
@@ -26,8 +26,10 @@ struct Inner<T> {
 impl<T> Inner<T> {
     /// Try and deallocate interior value of refcount has reached zero.
     unsafe fn try_dealloc(ptr: *mut Self) {
-        if (*ptr).weak + (*ptr).strong == 0 {
-            let _ = Box::from_raw(ptr);
+        unsafe {
+            if (*ptr).weak + (*ptr).strong == 0 {
+                let _ = Box::from_raw(ptr);
+            }
         }
     }
 }
@@ -72,7 +74,7 @@ impl<T> BroadRc<T> {
     /// Caller must ensure that the reference returned by `get_mut_unchecked` is
     /// only used by one caller at the same time.
     pub unsafe fn get_mut_unchecked(&self) -> (&mut T, bool) {
-        let inner = &mut (*self.inner.as_ptr());
+        let inner = unsafe { &mut (*self.inner.as_ptr()) };
         (inner.value.get_mut(), inner.weak != 0)
     }
 }
@@ -90,7 +92,7 @@ impl<T> BroadWeak<T> {
     /// Caller must ensure that the reference returned by `get_mut_unchecked` is
     /// only used by one caller at the same time.
     pub unsafe fn get_mut_unchecked(&self) -> (&mut T, bool) {
-        let inner = &mut (*self.inner.as_ptr());
+        let inner = unsafe { &mut (*self.inner.as_ptr()) };
         (inner.value.get_mut(), inner.strong != 0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@
 //! [futures::unsync]: <https://docs.rs/futures/0.1.31/futures/unsync/index.html>
 
 #![deny(missing_docs)]
+#![deny(rust_2018_idioms, unsafe_op_in_unsafe_fn)]
 #![allow(clippy::result_unit_err)]
 
 mod bi_rc;

--- a/src/once_cell.rs
+++ b/src/once_cell.rs
@@ -1,7 +1,5 @@
 //! [`OnceCell`] holds a value that can be written to only once.
 
-#![warn(unsafe_op_in_unsafe_fn)]
-
 use std::cell::UnsafeCell;
 use std::convert::Infallible;
 use std::fmt;

--- a/src/wait_list.rs
+++ b/src/wait_list.rs
@@ -1,5 +1,4 @@
 //! [`WaitList`] is an intrusively linked list of futures waiting on an event.
-#![warn(unsafe_op_in_unsafe_fn)]
 
 use std::cell::Cell;
 use std::cell::UnsafeCell;


### PR DESCRIPTION
It looks like this lint may become warn-by-default in future, and I think it is very helpful in `unsafe` contexts.