### PR TITLE
Make `noop_cx` a function

### DIFF
--- a/src/once_cell.rs
+++ b/src/once_cell.rs
@@ -75,7 +75,7 @@ impl<T> OnceCell<T> {
     /// use std::task::Poll;
     ///
     /// use unsync::once_cell::{OnceCell, SetResult};
-    /// # unsync::utils::noop_cx!(cx);
+    /// # let cx = &mut unsync::utils::noop_cx();
     ///
     /// let cell = OnceCell::new();
     ///
@@ -148,7 +148,7 @@ impl<T> OnceCell<T> {
     /// use std::task::Poll;
     ///
     /// use unsync::once_cell::{OnceCell, SetResult};
-    /// # unsync::utils::noop_cx!(cx);
+    /// # let cx = &mut unsync::utils::noop_cx();
     ///
     /// let cell = OnceCell::<i32>::new();
     ///
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     fn insert_when_initializing() {
-        noop_cx!(cx);
+        let cx = &mut noop_cx();
 
         let cell = OnceCell::new();
 

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -216,7 +216,7 @@ impl Semaphore {
     /// use std::task::Poll;
     ///
     /// use unsync::Semaphore;
-    /// # unsync::utils::noop_cx!(cx);
+    /// # let cx = &mut unsync::utils::noop_cx();
     ///
     /// let semaphore = Semaphore::new(1);
     ///
@@ -284,7 +284,7 @@ impl Semaphore {
     /// use unsync::Semaphore;
     ///
     /// # #[tokio::main(flavor = "current_thread")] async fn main() {
-    /// # unsync::utils::noop_cx!(cx);
+    /// # let cx = &mut unsync::utils::noop_cx();
     /// let semaphore = Semaphore::new(1);
     ///
     /// {
@@ -357,7 +357,7 @@ impl Semaphore {
 /// use std::task::Poll;
 ///
 /// use unsync::Semaphore;
-/// # unsync::utils::noop_cx!(cx);
+/// # let cx = &mut unsync::utils::noop_cx();
 ///
 /// let semaphore = Semaphore::new(1);
 ///
@@ -443,7 +443,7 @@ impl<'semaphore> Permit<'semaphore> {
     /// use std::task::Poll;
     ///
     /// use unsync::Semaphore;
-    /// # unsync::utils::noop_cx!(cx);
+    /// # let cx = &mut unsync::utils::noop_cx();
     ///
     /// let semaphore = Semaphore::new(1);
     ///

--- a/src/wait_list.rs
+++ b/src/wait_list.rs
@@ -358,7 +358,7 @@ impl<'wait_list, I, O> Borrowed<'wait_list, I, O> {
     ///
     /// use unsync::wait_list::WaitList;
     ///
-    /// # unsync::utils::noop_cx!(cx);
+    /// # let cx = &mut unsync::utils::noop_cx();
     /// let list = WaitList::<u32, u32>::new();
     /// let mut future = Box::pin(list.wait(5));
     /// assert_eq!(future.as_mut().poll(cx), Poll::Pending);
@@ -377,7 +377,7 @@ impl<'wait_list, I, O> Borrowed<'wait_list, I, O> {
     ///
     /// use unsync::wait_list::WaitList;
     ///
-    /// # unsync::utils::noop_cx!(cx);
+    /// # let cx = &mut unsync::utils::noop_cx();
     /// let list = WaitList::<u32, u32>::new();
     ///
     /// let mut f1 = Box::pin(list.wait(1));
@@ -530,7 +530,7 @@ mod tests {
 
     #[test]
     fn cancel() {
-        noop_cx!(cx);
+        let cx = &mut noop_cx();
 
         let list = WaitList::<u32, ()>::new();
         let mut future = Box::pin(list.wait(5));
@@ -544,7 +544,7 @@ mod tests {
 
     #[test]
     fn drop_in_middle() {
-        noop_cx!(cx);
+        let cx = &mut noop_cx();
 
         let list = WaitList::<u32, ()>::new();
         let mut f1 = Box::pin(list.wait(1));


### PR DESCRIPTION
This also resolves the issue of accidentally making `noop_cx!` a public and documented item at the crate root.

The only disadvantage is the `unsafe` transmute from `RawWaker` → `Waker`. But it's perfectly sound since the `#[repr(transparent)]` guarantees them to have the same layout.