### PR TITLE
spsc: fix two lost-wakeup bugs in the channel

### DIFF
--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -262,6 +262,11 @@ impl<T> Future for Recv<'_, T> {
             let (inner, both_present) = this.inner.get_mut_unchecked();
 
             if let Some(value) = inner.buf.pop_front() {
+                // Popping freed capacity, so wake a sender waiting to send.
+                if let Some(tx) = &inner.tx {
+                    tx.wake_by_ref();
+                }
+
                 return Poll::Ready(Some(value));
             }
 
@@ -349,9 +354,10 @@ mod tests {
     use std::future::Future;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
-    use std::task::{Context, Wake, Waker};
+    use std::task::{Context, Poll, Wake, Waker};
 
     use super::channel;
+    use crate::utils::noop_cx;
 
     struct Flag(AtomicBool);
 
@@ -382,5 +388,26 @@ mod tests {
         tx.try_send(1).unwrap();
 
         assert!(second.0.load(Ordering::SeqCst), "latest waker was not woken");
+    }
+
+    // A sender blocked on a full channel must be woken when the receiver pops a
+    // value (freeing capacity), not only the next time it finds the queue empty.
+    #[test]
+    fn recv_wakes_blocked_sender_on_pop() {
+        let (mut tx, mut rx) = channel::<u32>(1);
+        tx.try_send(1).unwrap();
+
+        let sender = Arc::new(Flag(AtomicBool::new(false)));
+        let ws = Waker::from(sender.clone());
+
+        // The channel is full, so this send parks and registers `ws`.
+        let mut send = Box::pin(tx.send(2));
+        assert!(send.as_mut().poll(&mut Context::from_waker(&ws)).is_pending());
+
+        // Popping a value frees capacity and must wake the parked sender.
+        let mut recv = Box::pin(rx.recv());
+        assert_eq!(recv.as_mut().poll(&mut noop_cx()), Poll::Ready(Some(1)));
+
+        assert!(sender.0.load(Ordering::SeqCst), "blocked sender was not woken");
     }
 }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -270,7 +270,7 @@ impl<T> Future for Recv<'_, T> {
                 return Poll::Ready(None);
             }
 
-            if !matches!(&inner.rx, Some(w) if !w.will_wake(cx.waker())) {
+            if !matches!(&inner.rx, Some(w) if w.will_wake(cx.waker())) {
                 inner.rx = Some(cx.waker().clone())
             }
 
@@ -342,4 +342,45 @@ pub fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
     let tx = Sender { inner: b };
 
     (tx, rx)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::task::{Context, Wake, Waker};
+
+    use super::channel;
+
+    struct Flag(AtomicBool);
+
+    impl Wake for Flag {
+        fn wake(self: Arc<Self>) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    // A `recv` re-polled with a new waker (e.g. moved between tasks) must register
+    // it. Otherwise a later send wakes the old waker and the receiver never runs.
+    #[test]
+    fn recv_updates_changed_waker() {
+        let (mut tx, mut rx) = channel::<u32>(1);
+
+        let first = Arc::new(Flag(AtomicBool::new(false)));
+        let second = Arc::new(Flag(AtomicBool::new(false)));
+        let w1 = Waker::from(first.clone());
+        let w2 = Waker::from(second.clone());
+
+        let mut fut = Box::pin(rx.recv());
+        assert!(fut.as_mut().poll(&mut Context::from_waker(&w1)).is_pending());
+        assert!(fut.as_mut().poll(&mut Context::from_waker(&w2)).is_pending());
+
+        tx.try_send(1).unwrap();
+
+        assert!(second.0.load(Ordering::SeqCst), "latest waker was not woken");
+    }
 }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -382,12 +382,21 @@ mod tests {
         let w2 = Waker::from(second.clone());
 
         let mut fut = Box::pin(rx.recv());
-        assert!(fut.as_mut().poll(&mut Context::from_waker(&w1)).is_pending());
-        assert!(fut.as_mut().poll(&mut Context::from_waker(&w2)).is_pending());
+        assert!(fut
+            .as_mut()
+            .poll(&mut Context::from_waker(&w1))
+            .is_pending());
+        assert!(fut
+            .as_mut()
+            .poll(&mut Context::from_waker(&w2))
+            .is_pending());
 
         tx.try_send(1).unwrap();
 
-        assert!(second.0.load(Ordering::SeqCst), "latest waker was not woken");
+        assert!(
+            second.0.load(Ordering::SeqCst),
+            "latest waker was not woken"
+        );
     }
 
     // A sender blocked on a full channel must be woken when the receiver pops a
@@ -402,12 +411,18 @@ mod tests {
 
         // The channel is full, so this send parks and registers `ws`.
         let mut send = Box::pin(tx.send(2));
-        assert!(send.as_mut().poll(&mut Context::from_waker(&ws)).is_pending());
+        assert!(send
+            .as_mut()
+            .poll(&mut Context::from_waker(&ws))
+            .is_pending());
 
         // Popping a value frees capacity and must wake the parked sender.
         let mut recv = Box::pin(rx.recv());
         assert_eq!(recv.as_mut().poll(&mut noop_cx()), Poll::Ready(Some(1)));
 
-        assert!(sender.0.load(Ordering::SeqCst), "blocked sender was not woken");
+        assert!(
+            sender.0.load(Ordering::SeqCst),
+            "blocked sender was not woken"
+        );
     }
 }


### PR DESCRIPTION
## Problem

Two separate lost-wakeup bugs in the spsc channel.

**1. Stale receiver waker.** `Recv::poll` only replaced the stored waker when it was *already* current:

```rust
if !matches!(&inner.rx, Some(w) if !w.will_wake(cx.waker())) {
    inner.rx = Some(cx.waker().clone())
}
```

The extra `!` inverts the intent. When the stored waker is stale (a `recv` re-polled under a *different* waker, for example after the future is moved to another task) it is not updated, so a later send wakes the old task and the receiver never makes progress. `Send::poll` and the oneshot receiver use the correct form (`Some(w) if w.will_wake(...)`).

**2. Sender not woken on consume.** A sender blocked on a full bounded channel was only woken the next time `recv` found the queue *empty*, not when it actually popped a value and freed a slot. If the receiver consumed one item without looping back into `recv`, the sender could stall even though there is now room.

## Fix

1. Remove the inverted `!` so a stale waker is replaced with the current one.
2. Wake the sender from the pop path in `Recv::poll`, where capacity is actually freed.

## Testing

Added unit tests using two distinct tracking wakers: a `recv` re-polled with a new waker is the one woken by the next send, and a sender blocked on a full channel is woken when the receiver pops. `cargo test` and Miri pass.

---

*Note: this change was developed with AI assistance and reviewed by me before submission.*
