### PR TITLE
semaphore: fix permit leak, stranding, and a multi-waiter deadlock

### DIFF
--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -288,7 +288,15 @@ impl Semaphore {
             }
 
             match self.waiters.wait(to_acquire).await {
-                WakeUp::Unfair => continue,
+                WakeUp::Unfair => {
+                    // We were woken from the head of the queue, so take the
+                    // permits without deferring to waiters still queued behind
+                    // us. Plain `try_acquire` would refuse here because the queue
+                    // is non-empty, leaving the released permits unclaimed.
+                    if let Some(guard) = self.try_acquire_unfair(to_acquire) {
+                        break guard;
+                    }
+                }
                 WakeUp::Fair(grant) => {
                     // The `Permit` below owns these permits now; forget the grant
                     // so they aren't released twice.
@@ -561,5 +569,23 @@ mod tests {
         // `f1`'s reserved permit must flow to `f2`.
         drop(f1);
         assert!(f2.as_mut().poll(cx).is_ready());
+    }
+
+    // Releasing one permit while two tasks wait must let the first waiter take
+    // it. The just-woken front waiter must not defer to the task queued behind
+    // it (which would leave both parked and the permit unclaimed).
+    #[test]
+    fn release_wakes_front_waiter_with_another_queued() {
+        let cx = &mut noop_cx();
+        let sem = Semaphore::new(1);
+        let initial = sem.try_acquire(1).unwrap();
+
+        let mut f1 = Box::pin(sem.acquire(1));
+        let mut f2 = Box::pin(sem.acquire(1));
+        assert!(f1.as_mut().poll(cx).is_pending());
+        assert!(f2.as_mut().poll(cx).is_pending());
+
+        drop(initial);
+        assert!(f1.as_mut().poll(cx).is_ready());
     }
 }

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -70,10 +70,26 @@ enum Fairness {
 /// The value handed to a woken waiter through the wait list.
 enum WakeUp {
     /// Permits may be available; the waiter must re-contend via `try_acquire`.
-    Unfair,
+    /// The token passes the wakeup on if this waiter is cancelled before doing so.
+    Unfair(UnfairWoken),
     /// The requested permits were granted directly. The grant holds them until
     /// the waiter turns it into a `Permit`.
     Fair(FairGrant),
+}
+
+/// Handed to a waiter woken by an unfair release so it can contend for permits.
+/// If the waiter is cancelled before contending, this `Drop` re-runs the wake so
+/// the permits are offered to the next waiter rather than left stranded.
+struct UnfairWoken {
+    semaphore: *const Semaphore,
+}
+
+impl Drop for UnfairWoken {
+    fn drop(&mut self) {
+        // SAFETY: the semaphore outlives every waiter holding a token.
+        let semaphore = unsafe { &*self.semaphore };
+        semaphore.release_permits(0, Fairness::Unfair);
+    }
 }
 
 /// Permits reserved for a specific waiter by a fair release. If the waiter
@@ -288,12 +304,14 @@ impl Semaphore {
             }
 
             match self.waiters.wait(to_acquire).await {
-                WakeUp::Unfair => {
+                WakeUp::Unfair(token) => {
                     // We were woken from the head of the queue, so take the
-                    // permits without deferring to waiters still queued behind
-                    // us. Plain `try_acquire` would refuse here because the queue
-                    // is non-empty, leaving the released permits unclaimed.
+                    // permits without deferring to waiters still queued behind us
+                    // (plain `try_acquire` would refuse while the queue is
+                    // non-empty). On success forget the token; otherwise let it
+                    // drop, re-waking the next waiter so the wakeup isn't lost.
                     if let Some(guard) = self.try_acquire_unfair(to_acquire) {
+                        mem::forget(token);
                         break guard;
                     }
                 }
@@ -346,7 +364,15 @@ impl Semaphore {
             }
 
             match self.waiters.wait(to_acquire).await {
-                WakeUp::Unfair => continue,
+                WakeUp::Unfair(token) => {
+                    // Already at the head; take the permits now. On success
+                    // forget the token, otherwise let it drop and re-wake the
+                    // next waiter so the wakeup isn't lost.
+                    if let Some(guard) = self.try_acquire_unfair(to_acquire) {
+                        mem::forget(token);
+                        break guard;
+                    }
+                }
                 WakeUp::Fair(grant) => {
                     // The `Permit` below owns these permits now; forget the grant
                     // so they aren't released twice.
@@ -382,7 +408,7 @@ impl Semaphore {
                         permits: wanted_permits,
                     })
                 }
-                Fairness::Unfair => WakeUp::Unfair,
+                Fairness::Unfair => WakeUp::Unfair(UnfairWoken { semaphore: self }),
             };
 
             if waiters.wake_one(wake).is_err() {
@@ -587,5 +613,53 @@ mod tests {
 
         drop(initial);
         assert!(f1.as_mut().poll(cx).is_ready());
+    }
+
+    // Cancelling a woken waiter must not strand the permit it was woken for; the
+    // next waiter in line must still receive it.
+    #[test]
+    fn cancelled_woken_waiter_does_not_strand_permit() {
+        let cx = &mut noop_cx();
+        let sem = Semaphore::new(1);
+        let initial = sem.try_acquire(1).unwrap();
+
+        let mut w1 = Box::pin(sem.acquire(1));
+        let mut w2 = Box::pin(sem.acquire(1));
+        assert!(w1.as_mut().poll(cx).is_pending());
+        assert!(w2.as_mut().poll(cx).is_pending());
+
+        // Releasing one permit wakes the front waiter, `w1`.
+        drop(initial);
+
+        // `w1` is cancelled before it can take the permit.
+        drop(w1);
+
+        // The permit must flow to `w2`, not be lost.
+        assert!(w2.as_mut().poll(cx).is_ready());
+    }
+
+    // The re-woken permit must reach a still-queued waiter even when several are
+    // waiting behind the cancelled one.
+    #[test]
+    fn cancelled_woken_waiter_rewakes_across_queue() {
+        let cx = &mut noop_cx();
+        let sem = Semaphore::new(2);
+        let initial = sem.try_acquire(2).unwrap();
+
+        let mut w1 = Box::pin(sem.acquire(1));
+        let mut w2 = Box::pin(sem.acquire(1));
+        let mut w3 = Box::pin(sem.acquire(1));
+        assert!(w1.as_mut().poll(cx).is_pending());
+        assert!(w2.as_mut().poll(cx).is_pending());
+        assert!(w3.as_mut().poll(cx).is_pending());
+
+        // Releasing both permits wakes w1 and w2; w3 stays queued.
+        drop(initial);
+
+        // Cancelling w1 must hand its permit on to w3.
+        drop(w1);
+
+        assert!(w2.as_mut().poll(cx).is_ready());
+        assert!(w3.as_mut().poll(cx).is_ready());
     }
 }

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -1,6 +1,7 @@
 //! [`Semaphore`] provides an unsychronized asynchronous semaphore for permit acquisition.
 
 use std::cell::Cell;
+use std::mem;
 use std::mem::ManuallyDrop;
 
 use crate::wait_list::WaitList;
@@ -56,14 +57,40 @@ pub struct Semaphore {
     total_permits: Cell<usize>,
 }
 
-/// Ways in which a waiter can be woken.
+/// How permits are released to waiters.
 #[derive(Debug, Clone, Copy)]
-enum WakeUp {
-    /// The waiter was fairly given the number of permits it requested by `add_permits_fair`.
+enum Fairness {
+    /// Deducted up front and handed straight to the woken waiter, so no-one else
+    /// can take them.
     Fair,
-    /// The waiter was notified by `add_permits` that the requested number of permits may be
-    /// available, but wasn't given them directly.
+    /// Just made available; woken waiters re-contend for them via `try_acquire`.
     Unfair,
+}
+
+/// The value handed to a woken waiter through the wait list.
+enum WakeUp {
+    /// Permits may be available; the waiter must re-contend via `try_acquire`.
+    Unfair,
+    /// The requested permits were granted directly. The grant holds them until
+    /// the waiter turns it into a `Permit`.
+    Fair(FairGrant),
+}
+
+/// Permits reserved for a specific waiter by a fair release. If the waiter
+/// resumes it forgets the grant and turns it into a `Permit`; if it is cancelled
+/// first, this `Drop` hands the permits back to the semaphore instead of leaking
+/// them.
+struct FairGrant {
+    semaphore: *const Semaphore,
+    permits: usize,
+}
+
+impl Drop for FairGrant {
+    fn drop(&mut self) {
+        // SAFETY: the semaphore outlives every waiter holding a grant.
+        let semaphore = unsafe { &*self.semaphore };
+        semaphore.release_permits(self.permits, Fairness::Unfair);
+    }
 }
 
 impl Semaphore {
@@ -147,7 +174,7 @@ impl Semaphore {
                 .expect("number of permits overflowed"),
         );
 
-        self.release_permits(new_permits, WakeUp::Unfair);
+        self.release_permits(new_permits, Fairness::Unfair);
     }
 
     /// Add new permits to the semaphore, using a fair wakeup algorithm to
@@ -173,7 +200,7 @@ impl Semaphore {
     pub fn add_permits_fair(&self, new_permits: usize) {
         self.total_permits
             .set(self.total_permits.get().checked_add(new_permits).unwrap());
-        self.release_permits(new_permits, WakeUp::Fair);
+        self.release_permits(new_permits, Fairness::Fair);
     }
 
     /// Attempt to acquire permits from the semaphore immediately.
@@ -262,7 +289,10 @@ impl Semaphore {
 
             match self.waiters.wait(to_acquire).await {
                 WakeUp::Unfair => continue,
-                WakeUp::Fair => {
+                WakeUp::Fair(grant) => {
+                    // The `Permit` below owns these permits now; forget the grant
+                    // so they aren't released twice.
+                    mem::forget(grant);
                     return Permit {
                         semaphore: self,
                         permits: to_acquire,
@@ -309,7 +339,10 @@ impl Semaphore {
 
             match self.waiters.wait(to_acquire).await {
                 WakeUp::Unfair => continue,
-                WakeUp::Fair => {
+                WakeUp::Fair(grant) => {
+                    // The `Permit` below owns these permits now; forget the grant
+                    // so they aren't released twice.
+                    mem::forget(grant);
                     return Permit {
                         semaphore: self,
                         permits: to_acquire,
@@ -319,7 +352,7 @@ impl Semaphore {
         }
     }
 
-    fn release_permits(&self, permits: usize, fairness: WakeUp) {
+    fn release_permits(&self, permits: usize, fairness: Fairness) {
         let mut permits = self.permits.get() + permits;
         self.permits.set(permits);
 
@@ -331,11 +364,20 @@ impl Semaphore {
                 None => break,
             };
 
-            if let WakeUp::Fair = fairness {
-                self.permits.set(permits);
-            }
+            let wake = match fairness {
+                Fairness::Fair => {
+                    // Commit the deduction; the grant returns the permits if the
+                    // waiter is cancelled before it claims them.
+                    self.permits.set(permits);
+                    WakeUp::Fair(FairGrant {
+                        semaphore: self,
+                        permits: wanted_permits,
+                    })
+                }
+                Fairness::Unfair => WakeUp::Unfair,
+            };
 
-            if waiters.wake_one(fairness).is_err() {
+            if waiters.wake_one(wake).is_err() {
                 // Hint that the `None` branch can be optimized away. We know
                 // this is unreachable since we've cheat that an head input
                 // exists above.
@@ -460,13 +502,64 @@ impl<'semaphore> Permit<'semaphore> {
     /// ```
     pub fn release_fair(self) {
         let this = ManuallyDrop::new(self);
-        this.semaphore.release_permits(this.permits, WakeUp::Fair);
+        this.semaphore.release_permits(this.permits, Fairness::Fair);
     }
 }
 
 impl Drop for Permit<'_> {
     fn drop(&mut self) {
         self.semaphore()
-            .release_permits(self.permits(), WakeUp::Unfair);
+            .release_permits(self.permits(), Fairness::Unfair);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+
+    use super::Semaphore;
+    use crate::utils::noop_cx;
+
+    // A fair release reserves the permit for `f1`. If `f1` is dropped before
+    // claiming it, the permit must go back to the semaphore rather than leak.
+    #[test]
+    fn fair_grant_to_cancelled_waiter_is_not_leaked() {
+        let cx = &mut noop_cx();
+        let sem = Semaphore::new(1);
+
+        let initial = sem.try_acquire(1).unwrap();
+        assert_eq!(sem.available_permits(), 0);
+
+        let mut f1 = Box::pin(sem.acquire(1));
+        assert!(f1.as_mut().poll(cx).is_pending());
+
+        initial.release_fair();
+        assert_eq!(sem.available_permits(), 0);
+
+        drop(f1);
+
+        assert_eq!(sem.available_permits(), 1);
+        assert!(sem.try_acquire(1).is_some());
+    }
+
+    // The permits returned by a cancelled fair waiter must be able to wake the
+    // next waiter queued behind it (FairGrant::drop re-enters release_permits).
+    #[test]
+    fn permits_from_cancelled_fair_waiter_wake_next_waiter() {
+        let cx = &mut noop_cx();
+        let sem = Semaphore::new(1);
+
+        let initial = sem.try_acquire(1).unwrap();
+        let mut f1 = Box::pin(sem.acquire(1));
+        let mut f2 = Box::pin(sem.acquire(1));
+        assert!(f1.as_mut().poll(cx).is_pending());
+        assert!(f2.as_mut().poll(cx).is_pending());
+
+        initial.release_fair();
+        assert_eq!(sem.available_permits(), 0);
+
+        // `f1`'s reserved permit must flow to `f2`.
+        drop(f1);
+        assert!(f2.as_mut().poll(cx).is_ready());
     }
 }

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -662,4 +662,24 @@ mod tests {
         assert!(w2.as_mut().poll(cx).is_ready());
         assert!(w3.as_mut().poll(cx).is_ready());
     }
+
+    // Cancelling a parked (never-woken) waiter must leave the queue consistent so
+    // a later release still reaches the next waiter.
+    #[test]
+    fn parked_acquire_cancelled_then_release() {
+        let cx = &mut noop_cx();
+        let sem = Semaphore::new(1);
+        let held = sem.try_acquire(1).unwrap();
+
+        let mut a = Box::pin(sem.acquire(1));
+        let mut b = Box::pin(sem.acquire(1));
+        assert!(a.as_mut().poll(cx).is_pending());
+        assert!(b.as_mut().poll(cx).is_pending());
+
+        // Cancel the parked front waiter, then release a permit.
+        drop(a);
+        drop(held);
+
+        assert!(b.as_mut().poll(cx).is_ready());
+    }
 }


### PR DESCRIPTION
## Problem

Three issues around waking waiters, all reachable through the normal API.

**1. Fair grant leaked on cancel.** A fair release (`release_fair`, `add_permits_fair`) deducts permits up front and hands them to a specific woken waiter. If that waiter is cancelled after being woken but before turning the grant into a `Permit`, the permits were lost.

**2. Deadlock releasing to multiple waiters.** A woken fair `acquire` looped back to `try_acquire`, which refuses while *any* task is queued. With more than one waiter, the just-woken front waiter deferred to the task behind it and re-queued, so the released permit was never claimed and every waiter stalled. For example: two `acquire(1)` futures waiting, drop the permit holder, and neither proceeds.

**3. Unfair wakeup stranded on cancel.** An unfair release (the default `Permit::drop`) wakes the front waiters for the freed permits but carried no token. Cancelling a woken waiter dropped its wakeup; with another waiter queued, the freed permit was stranded and that waiter never woke.

## Fix

- Carry the fair wakeup in a `FairGrant` whose `Drop` returns the reserved permits to the semaphore, so a cancelled fair waiter releases them instead of leaking.
- On the wakeup path, acquire via `try_acquire_unfair`: the woken waiter is already at the head of the queue, so it should take the permits rather than defer to the waiters behind it.
- Carry the unfair wakeup in an `UnfairWoken` token whose `Drop` re-runs the wake, so a cancelled waiter passes its wakeup on to the next waiter. Both tokens are `mem::forget`-ten on a successful acquire, so there is no extra wake on the happy path.

## Testing

Added unit tests for each: a cancelled fair waiter does not leak, a cancelled fair waiter's permits reach the next waiter, releasing one permit with two and three waiters wakes the right ones, a cancelled woken waiter does not strand a permit (single and across the queue), and a cancelled parked waiter leaves the queue intact for a later release. `cargo test` passes, as does Miri under both Stacked Borrows and Tree Borrows.

---

*Note: this change was developed with AI assistance and reviewed by me before submission.*
